### PR TITLE
config: allow qa website hosts

### DIFF
--- a/wielandtech/settings.py
+++ b/wielandtech/settings.py
@@ -20,8 +20,10 @@ ALLOWED_HOSTS = [
     "wielandtech.com",
     "www.wielandtech.com",
     "dev.wielandtech.com",
+    "qa.wielandtech.com",
     "wielandtech.k8s.local",
     "dev.wielandtech.k8s.local",
+    "qa.wielandtech.k8s.local",
     "127.0.0.1",
     "174.138.92.200",
     "159.89.246.9",
@@ -33,8 +35,14 @@ CSRF_TRUSTED_ORIGINS = [
     "https://wielandtech.com",
     "https://wielandtech.k8s.local",
     "http://wielandtech.k8s.local",
+    "http://dev.wielandtech.com",
+    "https://dev.wielandtech.com",
+    "http://qa.wielandtech.com",
+    "https://qa.wielandtech.com",
     "http://dev.wielandtech.k8s.local",
-    "https://dev.wielandtech.k8s.local"
+    "https://dev.wielandtech.k8s.local",
+    "http://qa.wielandtech.k8s.local",
+    "https://qa.wielandtech.k8s.local"
 ]
 
 SITE_ID = 1


### PR DESCRIPTION
## Summary
- Allow qa.wielandtech.com and qa.wielandtech.k8s.local in Django ALLOWED_HOSTS
- Add dev/qa public and k8s-local origins to CSRF_TRUSTED_ORIGINS

## Validation
- git diff --check