### PR TITLE
ci: publish review app image tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,6 +17,9 @@ jobs:
     
     steps:
     - uses: actions/checkout@v6
+      with:
+        repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+        ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -48,6 +51,12 @@ jobs:
           DEV_TAG="ghcr.io/wielandtech/w_tech:dev-${DATE}-${TIME}-${SHA}"
           echo "dev_tag=dev-${DATE}-${TIME}-${SHA}" >> $GITHUB_OUTPUT
           echo "Created dev tag: ${DEV_TAG}"
+        elif [ "${{ github.event_name }}" == "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]; then
+          PR_TAG="ghcr.io/wielandtech/w_tech:pr-${{ github.event.pull_request.number }}-${SHA}"
+          echo "pr_tag=pr-${{ github.event.pull_request.number }}-${SHA}" >> $GITHUB_OUTPUT
+          echo "Created review app tag: ${PR_TAG}"
+        elif [ "${{ github.event_name }}" == "pull_request" ]; then
+          echo "Skipping registry promotion tag for fork pull request"
         else
           echo "Skipping registry promotion tag (not a push event)"
         fi
@@ -64,13 +73,14 @@ jobs:
           type=raw,value=latest,enable={{is_default_branch}}
           type=raw,value=${{ steps.vars.outputs.release_tag }},enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           type=raw,value=${{ steps.vars.outputs.dev_tag }},enable=${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
+          type=raw,value=${{ steps.vars.outputs.pr_tag }},enable=${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       id: build
       with:
         context: .
-        push: ${{ github.event_name != 'pull_request' }}
+        push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha


### PR DESCRIPTION
## Summary
- publish same-repo pull request images as ghcr.io/wielandtech/w_tech:pr-<number>-<sha>
- keep fork PRs build-only without registry push
- preserve existing main production tags and branch dev tags

## Validation
- parsed .github/workflows/docker-build.yml with PyYAML
- git diff --check