### PR TITLE
feat: dispatch website review apps

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -85,3 +85,44 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    - name: Dispatch review app update
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+      env:
+        HOMELAB_REVIEW_APP_TOKEN: ${{ secrets.HOMELAB_REVIEW_APP_TOKEN }}
+        GH_TOKEN: ${{ secrets.HOMELAB_REVIEW_APP_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        IMAGE_TAG: ${{ steps.vars.outputs.pr_tag }}
+        SHORT_SHA: ${{ steps.vars.outputs.sha }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [ -z "${HOMELAB_REVIEW_APP_TOKEN:-}" ]; then
+          echo "HOMELAB_REVIEW_APP_TOKEN is not set; skipping review app update dispatch."
+          exit 0
+        fi
+
+        jq -n \
+          --arg action "upsert" \
+          --arg pr_number "$PR_NUMBER" \
+          --arg source_repo "$GITHUB_REPOSITORY" \
+          --arg source_pr_url "$PR_URL" \
+          --arg image_tag "$IMAGE_TAG" \
+          --arg short_sha "$SHORT_SHA" \
+          '{
+            event_type: "w-tech-review-app",
+            client_payload: {
+              action: $action,
+              pr_number: ($pr_number | tonumber),
+              source_repo: $source_repo,
+              source_pr_url: $source_pr_url,
+              image_tag: $image_tag,
+              short_sha: $short_sha
+            }
+          }' \
+          | gh api repos/wielandtech/w_homelab/dispatches \
+              --method POST \
+              --header "Accept: application/vnd.github+json" \
+              --input -

--- a/.github/workflows/review-app-dispatch.yml
+++ b/.github/workflows/review-app-dispatch.yml
@@ -1,0 +1,47 @@
+name: Dispatch Review App Cleanup
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ closed ]
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch review app cleanup
+        env:
+          HOMELAB_REVIEW_APP_TOKEN: ${{ secrets.HOMELAB_REVIEW_APP_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOMELAB_REVIEW_APP_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${HOMELAB_REVIEW_APP_TOKEN:-}" ]; then
+            echo "HOMELAB_REVIEW_APP_TOKEN is not set; skipping review app cleanup dispatch."
+            exit 0
+          fi
+
+          jq -n \
+            --arg action "delete" \
+            --arg pr_number "$PR_NUMBER" \
+            --arg source_repo "$GITHUB_REPOSITORY" \
+            --arg source_pr_url "$PR_URL" \
+            '{
+              event_type: "w-tech-review-app",
+              client_payload: {
+                action: $action,
+                pr_number: ($pr_number | tonumber),
+                source_repo: $source_repo,
+                source_pr_url: $source_pr_url
+              }
+            }' \
+            | gh api repos/wielandtech/w_homelab/dispatches \
+                --method POST \
+                --header "Accept: application/vnd.github+json" \
+                --input -

--- a/wielandtech/settings.py
+++ b/wielandtech/settings.py
@@ -21,6 +21,7 @@ ALLOWED_HOSTS = [
     "www.wielandtech.com",
     "dev.wielandtech.com",
     "qa.wielandtech.com",
+    ".review.wielandtech.com",
     "wielandtech.k8s.local",
     "dev.wielandtech.k8s.local",
     "qa.wielandtech.k8s.local",
@@ -39,6 +40,7 @@ CSRF_TRUSTED_ORIGINS = [
     "https://dev.wielandtech.com",
     "http://qa.wielandtech.com",
     "https://qa.wielandtech.com",
+    "https://*.review.wielandtech.com",
     "http://dev.wielandtech.k8s.local",
     "https://dev.wielandtech.k8s.local",
     "http://qa.wielandtech.k8s.local",
@@ -111,16 +113,24 @@ TEMPLATES = [
 WSGI_APPLICATION = 'wielandtech.wsgi.application'
 
 # Database
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.getenv("DATABASE_NAME", "app_db"),
-        'USER': os.getenv("DATABASE_USER", "app_user"),
-        'PASSWORD': os.getenv("DATABASE_PASSWORD"),
-        'HOST': os.getenv("DATABASE_HOST", "db"),
-        'PORT': os.getenv("DATABASE_PORT", "5432"),
+if os.getenv("DATABASE_ENGINE") == "sqlite":
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': os.getenv("DATABASE_NAME", str(BASE_DIR / "db.sqlite3")),
+        }
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': os.getenv("DATABASE_NAME", "app_db"),
+            'USER': os.getenv("DATABASE_USER", "app_user"),
+            'PASSWORD': os.getenv("DATABASE_PASSWORD"),
+            'HOST': os.getenv("DATABASE_HOST", "db"),
+            'PORT': os.getenv("DATABASE_PORT", "5432"),
+        }
+    }
 
 # Password validation
 AUTH_PASSWORD_VALIDATORS = [


### PR DESCRIPTION
## Summary
- allow review app hosts under *.review.wielandtech.com
- add sqlite database mode for disposable review apps
- dispatch homelab review-app upsert events after same-repo PR images are pushed
- dispatch homelab cleanup events when source PRs close

## Validation
- parsed workflow YAML with PyYAML
- python -m py_compile wielandtech/settings.py
- git diff --check

## Follow-up setup
- add HOMELAB_REVIEW_APP_TOKEN secret to this repository
- add wildcard DNS for *.review.wielandtech.com pointing at Traefik