### PR TITLE
Clean up stale wielandtech/* links (post-migration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The homelab Flux Image Automation watches the `dev-*` tags for the shared `websi
 
 1. Clone repository:
 ```bash
-git clone https://github.com/wielandtech/w_tech.git
+git clone https://github.com/wielandtech-labs/w_tech.git
 cd wielandtech
 ```
 

--- a/core/templates/core/homelab.html
+++ b/core/templates/core/homelab.html
@@ -17,7 +17,7 @@
     <div class="homelab-section">
         <div class="section-header">
             <h2>Live Cluster Metrics</h2>
-            <a href="https://github.com/wielandtech/w_lab" target="_blank" rel="noopener noreferrer" class="section-repo-link">
+            <a href="https://github.com/wielandtech-labs/w_lab" target="_blank" rel="noopener noreferrer" class="section-repo-link">
                 <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">
                     <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
                 </svg>

--- a/core/templates/core/projects.html
+++ b/core/templates/core/projects.html
@@ -11,7 +11,7 @@
 
 	<p class="date float_right">2025</p>
 
-	<p class="job"><a href="https://github.com/wielandtech/w_lab" target="_blank">w/homelab</a> - Kubernetes Homelab</p>
+	<p class="job"><a href="https://github.com/wielandtech-labs/w_lab" target="_blank">w/homelab</a> - Kubernetes Homelab</p>
 
 	<p>
 		Built a production-grade Kubernetes homelab using GitOps principles with automated deployment and configuration management.


### PR DESCRIPTION
Repoint the website's repo links (homelab/projects templates) + README to wielandtech-labs. Merging rebuilds + redeploys the site with corrected links.