### PR TITLE
feat(ci): add mTLS driver-opts to buildx remote setup

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,6 +36,10 @@ jobs:
       with:
         driver: remote
         endpoint: tcp://buildkitd.buildkit.svc.cluster.local:1234
+        driver-opts: |
+          cacert=/etc/buildkit/certs/ca.crt
+          cert=/etc/buildkit/certs/tls.crt
+          key=/etc/buildkit/certs/tls.key
     
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v4


### PR DESCRIPTION
## Summary
Adds `driver-opts` with client cert paths to the `docker/setup-buildx-action` step so builds can authenticate to the mTLS-enabled buildkitd.

The cert is mounted at `/etc/buildkit/certs/` in every `homelab-dind` runner pod via the ARC HelmRelease change in [w_homelab #297](https://github.com/wielandtech-labs/w_homelab/pull/297).

## ⚠️ Merge after w_homelab #297
This PR must merge **after** w_homelab PR #297 is deployed.

## Test plan
- [ ] Trigger a build after both PRs are merged → build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)