### PR TITLE
ci: report the required build check on docs-only PRs

### DIFF
--- a/.github/workflows/docs-only-build-pass.yml
+++ b/.github/workflows/docs-only-build-pass.yml
@@ -1,0 +1,25 @@
+# Companion to docker-build.yml for the required "build" branch-protection
+# check. docker-build.yml path-ignores docs ("**.md", "docs/**"), so a
+# docs-only PR would never report the required check and could never merge.
+# This workflow triggers on exactly the inverse paths and reports a job with
+# the SAME name ("build") that passes immediately.
+#
+# Keep the paths here in sync with docker-build.yml's paths-ignore.
+name: Build (docs-only pass)
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "**.md"
+      - "docs/**"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docs-only change
+        run: echo "Docs-only change — image build not required; reporting the required 'build' check as passed."


### PR DESCRIPTION
Fixes the branch-protection deadlock where docs-only PRs (like #27) can never merge: the required `build` check comes from `docker-build.yml`, which path-ignores `**.md`/`docs/**`, so the check never reports. This adds GitHub's documented companion-workflow pattern — same job name (`build`), inverse path filter, instant pass — so every PR reports exactly one (or both, for mixed changes) `build` check.

Note: this PR changes a workflow file (not docs), so the real build runs and reports normally here. Side effect of any w_tech PR: a review app spins up; it'll be cleaned up when this closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)