### PR TITLE
fix(ci): run review-app cleanup on org-scoped runner pool

### DIFF
--- a/.github/workflows/review-app-dispatch.yml
+++ b/.github/workflows/review-app-dispatch.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: homelab
+    runs-on: homelab-dind
     steps:
       - name: Dispatch review app cleanup
         env:
@@ -45,5 +45,5 @@ jobs:
                 -H "Accept: application/vnd.github+json" \
                 -H "Authorization: Bearer ${HOMELAB_REVIEW_APP_TOKEN}" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/wielandtech/w_homelab/dispatches \
+                https://api.github.com/repos/wielandtech-labs/w_homelab/dispatches \
                 --data-binary @-


### PR DESCRIPTION
## Problem

The `Dispatch Review App Cleanup` / `cleanup` job uses `runs-on: homelab`, but the `homelab` ARC runner scale set is registered **repo-scoped to `wielandtech-labs/w_homelab`** (its `githubConfigUrl` is that repo). A w_tech job targeting that label can never be assigned a runner and queues forever — e.g. [run 27305119781](https://github.com/wielandtech-labs/w_tech/actions/runs/27305119781).

## Fix

- `runs-on: homelab` → `homelab-dind`, the org-scoped pool (`githubConfigUrl: https://github.com/wielandtech-labs`) already used by this repo's `docker-build.yml`.
- Point the `repository_dispatch` at `wielandtech-labs/w_homelab`. The old `wielandtech/w_homelab` API path now returns a **301** that the `curl` call doesn't follow, so even a running job would have silently no-op'd the cleanup dispatch.

## Verification plan

Merging this PR is itself a `pull_request: closed` event on main, which triggers the fixed workflow — the cleanup job should get a `homelab-dind` runner and the dispatch should land in w_homelab's `manage-review-app.yaml` (a safe no-op delete, since this PR has no review app). Stuck queued runs will be cancelled separately (re-running them would reuse the old workflow version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)