### PR TITLE
chore(homelab): update stale wielandtech/w_lab links to wielandtech-labs

### DIFF
--- a/core/templates/core/homelab.html
+++ b/core/templates/core/homelab.html
@@ -21,7 +21,7 @@
                 <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">
                     <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
                 </svg>
-                wielandtech/w_lab
+                wielandtech-labs/w_lab
             </a>
         </div>
         <p>Real-time monitoring of my 3-node K3s cluster running on bare metal. Metrics are pulled directly from Netdata agents.</p>
@@ -174,20 +174,20 @@
     <div class="homelab-section">
         <h2>Gallery</h2>
         <div class="gallery-grid">
-            <a href="https://raw.githubusercontent.com/wielandtech/w_lab/main/w_homelab_front.jpg" target="_blank" class="gallery-item">
-                <img src="https://raw.githubusercontent.com/wielandtech/w_lab/main/w_homelab_front.jpg" alt="Homelab Front View">
+            <a href="https://raw.githubusercontent.com/wielandtech-labs/w_lab/main/w_homelab_front.jpg" target="_blank" class="gallery-item">
+                <img src="https://raw.githubusercontent.com/wielandtech-labs/w_lab/main/w_homelab_front.jpg" alt="Homelab Front View">
                 <span>Front View</span>
             </a>
-            <a href="https://raw.githubusercontent.com/wielandtech/w_lab/main/w_homelab_back.jpg" target="_blank" class="gallery-item">
-                <img src="https://raw.githubusercontent.com/wielandtech/w_lab/main/w_homelab_back.jpg" alt="Homelab Back View">
+            <a href="https://raw.githubusercontent.com/wielandtech-labs/w_lab/main/w_homelab_back.jpg" target="_blank" class="gallery-item">
+                <img src="https://raw.githubusercontent.com/wielandtech-labs/w_lab/main/w_homelab_back.jpg" alt="Homelab Back View">
                 <span>Back View</span>
             </a>
-            <a href="https://raw.githubusercontent.com/wielandtech/w_lab/main/w_homelab_left.jpg" target="_blank" class="gallery-item">
-                <img src="https://raw.githubusercontent.com/wielandtech/w_lab/main/w_homelab_left.jpg" alt="Homelab Left Side">
+            <a href="https://raw.githubusercontent.com/wielandtech-labs/w_lab/main/w_homelab_left.jpg" target="_blank" class="gallery-item">
+                <img src="https://raw.githubusercontent.com/wielandtech-labs/w_lab/main/w_homelab_left.jpg" alt="Homelab Left Side">
                 <span>Left Side</span>
             </a>
-            <a href="https://raw.githubusercontent.com/wielandtech/w_lab/main/w_homelab_right.jpg" target="_blank" class="gallery-item">
-                <img src="https://raw.githubusercontent.com/wielandtech/w_lab/main/w_homelab_right.jpg" alt="Homelab Right Side">
+            <a href="https://raw.githubusercontent.com/wielandtech-labs/w_lab/main/w_homelab_right.jpg" target="_blank" class="gallery-item">
+                <img src="https://raw.githubusercontent.com/wielandtech-labs/w_lab/main/w_homelab_right.jpg" alt="Homelab Right Side">
                 <span>Right Side</span>
             </a>
         </div>


### PR DESCRIPTION
## Why
Post-migration sweep for stale `wielandtech/*` references (org migration 2026-06-02) — follow-up to #23/#29, which missed these.

## What
`core/templates/core/homelab.html`:
- 8 gallery image URLs: `raw.githubusercontent.com/wielandtech/w_lab/...` → `wielandtech-labs/w_lab`. They currently work only via GitHub's transfer redirect, which breaks the day a new repo named `wielandtech/w_lab` exists.
- The visible repo-link label `wielandtech/w_lab` → `wielandtech-labs/w_lab` (the `href` was already correct).

The `wielandtech/` hits in README.md/SECURITY.md are the local Django project directory, not GitHub refs — untouched.

Note: this is a template change, so merging deploys to prod; verify the gallery renders on the review app first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)