### PR TITLE
fix(security): allow admin login over HTTP on internal hosts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,6 +20,12 @@ When `DEBUG=False`, the following security features are enabled:
 #### Cookie Security
 - `CSRF_COOKIE_SECURE = True` - CSRF cookies only sent over HTTPS
 - `SESSION_COOKIE_SECURE = True` - Session cookies only sent over HTTPS
+- **Internal-host exception**: `InternalAdminCookieMiddleware` strips the
+  `Secure` flag from the session/CSRF cookies for plain-HTTP requests on the
+  internal admin hosts (`wielandtech.k8s.local`, `127.0.0.1`, `localhost`).
+  Without this, admin login at `http://wielandtech.k8s.local/admin/` fails
+  CSRF verification because browsers never send `Secure` cookies over HTTP.
+  Public hosts keep fully `Secure` cookies.
 - `SESSION_COOKIE_HTTPONLY = True` - JavaScript cannot access session cookies
 - `CSRF_COOKIE_HTTPONLY = True` - JavaScript cannot access CSRF cookies
 - `SESSION_COOKIE_SAMESITE = 'Lax'` - CSRF protection

--- a/wielandtech/middleware.py
+++ b/wielandtech/middleware.py
@@ -4,6 +4,13 @@ Custom middleware for security and access control.
 from django.http import HttpResponseForbidden
 from django.conf import settings
 
+# Hosts allowed to reach the Django admin (LAN-only access paths).
+INTERNAL_ADMIN_HOSTS = [
+    'wielandtech.k8s.local',
+    '127.0.0.1',
+    'localhost',
+]
+
 
 class AllowMetricsEndpointMiddleware:
     """
@@ -33,12 +40,7 @@ class RestrictAdminMiddleware:
     """
     def __init__(self, get_response):
         self.get_response = get_response
-        # Define allowed hosts for admin access
-        self.allowed_admin_hosts = [
-            'wielandtech.k8s.local',
-            '127.0.0.1',
-            'localhost',
-        ]
+        self.allowed_admin_hosts = INTERNAL_ADMIN_HOSTS
 
     def __call__(self, request):
         # Check if accessing admin URLs
@@ -53,6 +55,30 @@ class RestrictAdminMiddleware:
                 )
         
         response = self.get_response(request)
+        return response
+
+
+class InternalAdminCookieMiddleware:
+    """
+    Strip the Secure flag from session/CSRF cookies on plain-HTTP requests
+    to internal admin hosts, so admin login works at
+    http://wielandtech.k8s.local/ while public hosts keep Secure cookies.
+    Must be placed BEFORE SessionMiddleware and CsrfViewMiddleware in
+    MIDDLEWARE so it processes the response after they set their cookies.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        host = request.get_host().split(':')[0]
+        if not request.is_secure() and host in INTERNAL_ADMIN_HOSTS:
+            for name in (settings.SESSION_COOKIE_NAME, settings.CSRF_COOKIE_NAME):
+                if name in response.cookies:
+                    # An empty value removes the Secure attribute
+                    response.cookies[name]['secure'] = ''
+
         return response
 
 

--- a/wielandtech/settings.py
+++ b/wielandtech/settings.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',  # Prometheus (must be first)
     'wielandtech.middleware.AllowMetricsEndpointMiddleware',  # Allow Prometheus scraping via pod IP
+    'wielandtech.middleware.InternalAdminCookieMiddleware',  # Must precede Session/Csrf middleware
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/wielandtech/tests.py
+++ b/wielandtech/tests.py
@@ -1,0 +1,47 @@
+"""
+Tests for custom middleware.
+"""
+from django.conf import settings
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase
+
+from wielandtech.middleware import InternalAdminCookieMiddleware
+
+
+class InternalAdminCookieMiddlewareTests(SimpleTestCase):
+    def _get_response_with_secure_cookies(self, request):
+        response = HttpResponse()
+        response.set_cookie(settings.SESSION_COOKIE_NAME, 'session-value', secure=True)
+        response.set_cookie(settings.CSRF_COOKIE_NAME, 'csrf-value', secure=True)
+        return response
+
+    def _run(self, host, secure, get_response=None):
+        middleware = InternalAdminCookieMiddleware(
+            get_response or self._get_response_with_secure_cookies
+        )
+        request = RequestFactory().get('/admin/login/', HTTP_HOST=host, secure=secure)
+        return middleware(request)
+
+    def assert_secure_flags(self, response, expected):
+        for name in (settings.SESSION_COOKIE_NAME, settings.CSRF_COOKIE_NAME):
+            self.assertEqual(bool(response.cookies[name]['secure']), expected, name)
+
+    def test_strips_secure_flag_for_http_on_internal_host(self):
+        response = self._run('wielandtech.k8s.local', secure=False)
+        self.assert_secure_flags(response, expected=False)
+
+    def test_keeps_secure_flag_for_https_on_internal_host(self):
+        response = self._run('wielandtech.k8s.local', secure=True)
+        self.assert_secure_flags(response, expected=True)
+
+    def test_keeps_secure_flag_for_public_host(self):
+        for secure in (False, True):
+            response = self._run('wielandtech.com', secure=secure)
+            self.assert_secure_flags(response, expected=True)
+
+    def test_response_without_cookies_passes_through(self):
+        response = self._run(
+            'wielandtech.k8s.local', secure=False,
+            get_response=lambda request: HttpResponse(),
+        )
+        self.assertEqual(len(response.cookies), 0)


### PR DESCRIPTION
## Problem

Admin login at `http://wielandtech.k8s.local/admin/login/` fails with **403 — CSRF verification failed**.

Root cause: prod runs `DEBUG=False`, which sets `CSRF_COOKIE_SECURE = True` / `SESSION_COOKIE_SECURE = True`. Browsers never store or send `Secure` cookies over plain HTTP, so the `csrftoken` cookie never reaches Django on the login POST. Host/origin config was already correct — this contradicted SECURITY.md's documented LAN admin access path.

## Fix

New `InternalAdminCookieMiddleware` strips the `Secure` flag from the session/CSRF cookies **only** for plain-HTTP requests on the internal admin hosts (`wielandtech.k8s.local`, `127.0.0.1`, `localhost`). Public hosts keep fully Secure cookies (`request.is_secure()` honors `X-Forwarded-Proto` from the proxy chain). The internal host list is now a shared module constant reused by `RestrictAdminMiddleware`.

## Verification

- 4 new unit tests in `wielandtech/tests.py` (`manage.py test wielandtech`) — all pass.
- E2E via Django test client through the full middleware stack:
  - `http://wielandtech.k8s.local/admin/login/` → 200, csrftoken **without** Secure ✅
  - `https://wielandtech.k8s.local/admin/login/` → 200, csrftoken with Secure ✅
  - `https://wielandtech.com/admin/login/` → 403 (still blocked) ✅
- Review app (regression check): public Set-Cookie headers must still carry `Secure`.
- Post-merge: log in at `http://wielandtech.k8s.local/admin/` from the LAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)